### PR TITLE
fix to allow topic name with hyphen in sql processor

### DIFF
--- a/webservice/src/main/resources/package.json
+++ b/webservice/src/main/resources/package.json
@@ -87,6 +87,7 @@
     "reactable": "0.14.1",
     "require-dir": "^0.3.0",
     "run-sequence": "^1.2.2",
+    "sqlite-parser": "^1.0.1",
     "style-loader": "^0.13.1",
     "system": "^1.0.6",
     "url-loader": "^0.5.7",


### PR DESCRIPTION
@harshach @satishwaghela 

Topic name (table name) with hyphens are allowed as long as it's passed using `double quotes` ("table_name-1") or `backquote` (\`table_name-1`)

For an alias, if user wants to have strict case they need to specify in double quotes else it will be treated as lower case (at least for now till we find a suitable solution to fix it)
For Example:

**Select field1 As Field1 from "topic-1" =>** output field will be **`field1`**

**Select field1 As "Field1" from "topic-1" =>** output field will be **`Field1`**