### PR TITLE
dynamic UI validation support for string and number types

### DIFF
--- a/webservice/src/main/resources/app/scripts/libs/form/Fields.jsx
+++ b/webservice/src/main/resources/app/scripts/libs/form/Fields.jsx
@@ -302,7 +302,19 @@ export class string extends BaseField {
   }
 
   validate() {
-    return super.validate(this.props.data[this.props.value]);
+    let {validation} = this.props.fieldJson;
+    let value = this.props.data[this.props.value];
+    let isValid = super.validate(value);
+    if(isValid){
+      if(validation && validation.regex){
+        let reg = new RegExp(validation.regex);
+        if(!reg.test(value)){
+          this.context.Form.state.Errors[this.props.valuePath] = validation.errorMessage;
+          isValid = false;
+        }
+      }
+    }
+    return isValid;
   }
 
   getField = () => {
@@ -646,16 +658,27 @@ export class number extends BaseField {
     this.validate();
   }
   validate() {
-    return super.validate(this.props.data[this.props.value]);
+    let {validation} = this.props.fieldJson;
+    let value = this.props.data[this.props.value];
+    let isValid = super.validate(value);
+    if(isValid){
+      if(validation && validation.min && value < validation.min){
+        isValid = false;
+      }
+      if(validation && validation.max && value > validation.max){
+        isValid = false;
+      }
+      if(!isValid){
+        this.context.Form.state.Errors[this.props.valuePath] = validation.errorMessage;
+      }
+    }
+    return isValid;
   }
   getField = () => {
     const numberHint = this.props.fieldJson.hint || null;
-    const min = this.props.fieldJson.min !== undefined
-      ? this.props.fieldJson.min
-      : 0;
-    const max = this.props.fieldJson.max !== undefined
-      ? this.props.fieldJson.max
-      : Number.MAX_SAFE_INTEGER;
+    let {validation} = this.props.fieldJson;
+    const min = (validation && validation.min) ? validation.min : 0;
+    const max = (validation && validation.max) ? validation.max : Number.MAX_SAFE_INTEGER;
     let disabledField = this.context.Form.props.readOnly;
     if (this.props.fieldJson.isUserInput !== undefined) {
       disabledField = disabledField || !this.props.fieldJson.isUserInput;

--- a/webservice/src/main/resources/app/scripts/libs/form/Form.jsx
+++ b/webservice/src/main/resources/app/scripts/libs/form/Form.jsx
@@ -120,12 +120,9 @@ export default class FSForm extends Component {
           if ((_.isNaN(val) || _.isUndefined(val)) && component.props.fieldJson.isOptional) {
             isFieldValid = true;
           } else {
-            const min = component.props.fieldJson.min === undefined
-              ? 0
-              : component.props.fieldJson.min;
-            const max = component.props.fieldJson.max === undefined
-              ? Number.MAX_SAFE_INTEGER
-              : component.props.fieldJson.max;
+            let {validation} = component.props.fieldJson;
+            const min = (validation && validation.min) ? validation.min : 0;
+            const max = (validation && validation.max) ? validation.max : Number.MAX_SAFE_INTEGER;
             isFieldValid = (val >= min && val <= max)
               ? true
               : false;

--- a/webservice/src/main/resources/app/scripts/libs/form/ValidationRules.js
+++ b/webservice/src/main/resources/app/scripts/libs/form/ValidationRules.js
@@ -16,14 +16,14 @@ import _ from 'lodash';
 
 let ValidationRules = {
   required: (value, form, component) => {
-    if (!value) {
+    if (!value && value !== 0) {
       return 'Required!';
     } else {
       if (value instanceof Array) {
         if (value.length === 0) {
           return 'Required!';
         }
-      } else if (value == '' || (typeof value == 'string' && value.trim() == '') || _.isUndefined(value)) {
+      } else if (value === '' || (typeof value == 'string' && value.trim() == '') || _.isUndefined(value)) {
         return 'Required!';
       } else {
         return '';


### PR DESCRIPTION
for string, add following snippet to JSON;

```
"validation": {
    "regex": "YOUR VALID REGEX",
    "errorMessage": "PROPER ERROR MESSAGE"
 }
```

For number, add following snippet to JSON:

```
"validation": {
    "min": MIN_NUMBER,
    "max": MAX_NUMBER,
    "errorMessage": "PROPER ERROR MESSAGE"
 }
```